### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     - name: check
       run: echo "SVC_VERSION = $SVC_VERSION"
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: frogfishio/user
         username: frogfishio


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore